### PR TITLE
Handshake check for nil instead of falsy

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = class ProtomuxRPC extends EventEmitter {
     this._channel = this._mux.createChannel({
       protocol,
       id,
-      handshake: handshake ? handshakeEncoding || c.raw : null,
+      handshake: (handshake != null) ? handshakeEncoding || c.raw : null,
       onopen: this._onopen.bind(this),
       onclose: this._onclose.bind(this),
       ondestroy: this._ondestroy.bind(this)


### PR DESCRIPTION
When handshake is zero (bitflag for example) or empty string, the encoder won't be recognized to decode the other side's handshake.

fixes https://github.com/holepunchto/protomux-rpc/issues/7