### PR TITLE
Add opened

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Options are the same as `new ProtomuxRPC(stream)`.
 
 Whether or not the RPC channel is closed.
 
+#### `rpc.opened`
+
+Whether or not the RPC channel is opened.
+
 #### `rpc.mux`
 
 The muxer used by the channel.

--- a/index.js
+++ b/index.js
@@ -165,6 +165,10 @@ module.exports = class ProtomuxRPC extends EventEmitter {
     this._endMaybe()
   }
 
+  get opened () {
+    return this._channel.opened
+  }
+
   get closed () {
     return this._channel.closed
   }

--- a/test.mjs
+++ b/test.mjs
@@ -1,3 +1,5 @@
+import { once } from 'events'
+
 import test from 'brittle'
 import Protomux from 'protomux'
 import { PassThrough } from 'streamx'
@@ -254,6 +256,14 @@ test('handshake, custom encoding', async (t) => {
   rpc.on('open', (handshake) => {
     t.is(handshake, 'hello')
   })
+})
+
+test('opened prop', async (t) => {
+  const rpc = new RPC(new PassThrough(), { handshake: Buffer.from('hello') })
+  t.is(rpc.opened, false, 'sanity check')
+
+  await once(rpc, 'open')
+  t.is(rpc.opened, true, 'opened=true after open')
 })
 
 test('multiple rpcs on same muxer', async (t) => {


### PR DESCRIPTION
Allows the pattern `if (!rpc.opened) await once(rpc, 'open')`