### PR TITLE
Add fullyOpened

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Cork the underlying channel. See [`channel.cork()`](https://github.com/mafintosh
 
 Uncork the underlying channel. See [`channel.uncork()`](https://github.com/mafintosh/protomux#channeluncork) for more information.
 
+#### `await rpc.fullyOpened()`
+
+Resolves when the rpc is fully setup, or rejects if the setup failed.
+
 #### `await rpc.end()`
 
 Gracefully end the RPC channel, waiting for all inflights requests and response handlers before closing.

--- a/index.js
+++ b/index.js
@@ -177,6 +177,10 @@ module.exports = class ProtomuxRPC extends EventEmitter {
     return this._mux.stream
   }
 
+  async fullyOpened () {
+    await this._channel.fullyOpened()
+  }
+
   respond (method, options, handler) {
     if (typeof options === 'function') {
       handler = options

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bits-to-bytes": "^1.0.0",
     "compact-encoding": "^2.6.1",
     "compact-encoding-bitfield": "^1.0.0",
-    "protomux": "^3.2.1",
+    "protomux": "^3.7.0",
     "safety-catch": "^1.0.2"
   },
   "optionalDependencies": {

--- a/test.mjs
+++ b/test.mjs
@@ -280,6 +280,13 @@ test('duplicate rpcs on same muxer throws', async (t) => {
   await t.exception(() => new RPC(mux), /duplicate channel/)
 })
 
+test('fullyOpened', async (t) => {
+  const rpc = new RPC(new PassThrough(), { handshake: Buffer.from('hello') })
+
+  await rpc.fullyOpened()
+  t.is(rpc._channel.opened, true, 'channel indeed open now') // TODO: direct opened prop
+})
+
 test('timeout', async (t) => {
   const rpc = new RPC(new PassThrough())
 

--- a/test.mjs
+++ b/test.mjs
@@ -294,7 +294,7 @@ test('fullyOpened', async (t) => {
   const rpc = new RPC(new PassThrough(), { handshake: Buffer.from('hello') })
 
   await rpc.fullyOpened()
-  t.is(rpc._channel.opened, true, 'channel indeed open now') // TODO: direct opened prop
+  t.is(rpc.opened, true, 'channel indeed open now')
 })
 
 test('timeout', async (t) => {


### PR DESCRIPTION
Note: fullyOpened was introduced only in protomux 3.7.0, so had to bump that dependency

<strike>Note: can make the test cleaner when https://github.com/holepunchto/protomux-rpc/pull/9 is in (no private prop access)</strike> Done
