### PR TITLE
Pass request-error codes through RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,20 @@ A request ID of `0` indicates an event call and must not be responded to.
 
 #### `response` (`1`)
 
-1.  `bitfield(1)` Flags
+1.  `bitfield(3)` Flags
     1.  `error`
+    2.  `code`
+    3.  `cause`
 2.  `uint` The ID of the request
-3.  (if `error` is set) `string` The error message
-4.  (if `error` is not set) `raw` The response value
+3.  (if `error` is set)
+    1.  `string` The error message
+4.  (if `error` and `code` is set)
+    1.  `string` The error code
+5.  (if `error` and `cause` is set)
+    1.  `string` The error cause message
+    2.  `string` The error cause code
+6.  (if `error` is not set)
+    1.  `raw` The response value
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ module.exports = class ProtomuxRPC extends EventEmitter {
 
     const responder = this._responders.get(method)
 
-    if (responder === undefined) error = new Error(`unknown method '${method}'`)
+    if (responder === undefined) error = errors.UNKNOWN_METHOD(`Unknown method '${method}'`)
     else {
       const {
         valueEncoding = this._defaultValueEncoding,
@@ -100,7 +100,7 @@ module.exports = class ProtomuxRPC extends EventEmitter {
       } catch (err) {
         safetyCatch(err)
 
-        error = err
+        error = errors.REQUEST_ERROR('Request error', err)
       }
 
       this._responding--
@@ -111,7 +111,7 @@ module.exports = class ProtomuxRPC extends EventEmitter {
         } catch (err) {
           safetyCatch(err)
 
-          error = err
+          error = errors.REQUEST_ERROR('Request error', err)
         }
       }
     }
@@ -132,7 +132,7 @@ module.exports = class ProtomuxRPC extends EventEmitter {
 
     if (request.timeout) clearTimeout(request.timeout)
 
-    if (error) request.reject(errors.REQUEST_ERROR('Request error', error))
+    if (error) request.reject(error)
     else {
       const {
         valueEncoding = this._defaultValueEncoding,

--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ module.exports = class ProtomuxRPC extends EventEmitter {
         value = await responder.handler(value)
       } catch (err) {
         safetyCatch(err)
+
         error = err
       }
 

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ module.exports = class ProtomuxRPC extends EventEmitter {
 
     if (request.timeout) clearTimeout(request.timeout)
 
-    if (error) request.reject(errors.REQUEST_ERROR('Request error',  error))
+    if (error) request.reject(errors.REQUEST_ERROR('Request error', error))
     else {
       const {
         valueEncoding = this._defaultValueEncoding,
@@ -324,11 +324,10 @@ const response = {
   },
   decode (state) {
     const [hasError] = bits.iterator(flags.decode(state))
-
     return {
       id: c.uint.decode(state),
       error: hasError ? error.decode(state) : null,
-      value: !error ? c.raw.decode(state) : null
+      value: !hasError ? c.raw.decode(state) : null
     }
   }
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -31,4 +31,8 @@ module.exports = class RPCError extends Error {
   static TIMEOUT_EXCEEDED (msg) {
     return new RPCError(msg, 'TIMEOUT_EXCEEDED', RPCError.TIMEOUT_EXCEEDED)
   }
+
+  static UNKNOWN_METHOD (msg) {
+    return new RPCError(msg, 'UNKNOWN_METHOD', RPCError.UNKNOWN_METHOD)
+  }
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -24,8 +24,8 @@ module.exports = class RPCError extends Error {
     return new RPCError(msg, 'CHANNEL_DESTROYED', RPCError.CHANNEL_DESTROYED)
   }
 
-  static REQUEST_ERROR (msg, code) {
-    return new RPCError(msg, code, RPCError.REQUEST_ERROR)
+  static REQUEST_ERROR (msg, cause) {
+    return new RPCError(msg,'REQUEST_ERROR', RPCError.REQUEST_ERROR, { cause })
   }
 
   static TIMEOUT_EXCEEDED (msg) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -25,7 +25,7 @@ module.exports = class RPCError extends Error {
   }
 
   static REQUEST_ERROR (msg, cause) {
-    return new RPCError(msg,'REQUEST_ERROR', RPCError.REQUEST_ERROR, { cause })
+    return new RPCError(msg, 'REQUEST_ERROR', RPCError.REQUEST_ERROR, { cause })
   }
 
   static TIMEOUT_EXCEEDED (msg) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -35,4 +35,12 @@ module.exports = class RPCError extends Error {
   static UNKNOWN_METHOD (msg) {
     return new RPCError(msg, 'UNKNOWN_METHOD', RPCError.UNKNOWN_METHOD)
   }
+
+  static DECODE_ERROR (msg, cause) {
+    return new RPCError(msg, 'DECODE_ERROR', RPCError.DECODE_ERROR, { cause })
+  }
+
+  static ENCODE_ERROR (msg, cause) {
+    return new RPCError(msg, 'ENCODE_ERROR', RPCError.ENCODE_ERROR, { cause })
+  }
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -24,8 +24,8 @@ module.exports = class RPCError extends Error {
     return new RPCError(msg, 'CHANNEL_DESTROYED', RPCError.CHANNEL_DESTROYED)
   }
 
-  static REQUEST_ERROR (msg) {
-    return new RPCError(msg, 'REQUEST_ERROR', RPCError.REQUEST_ERROR)
+  static REQUEST_ERROR (msg, code) {
+    return new RPCError(msg, code, RPCError.REQUEST_ERROR)
   }
 
   static TIMEOUT_EXCEEDED (msg) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,6 @@
 module.exports = class RPCError extends Error {
-  constructor (msg, code, fn = RPCError) {
-    super(`${code}: ${msg}`)
+  constructor (msg, code, fn = RPCError, { cause } = {}) {
+    super(`${code}: ${msg}`, { cause })
     this.code = code
 
     if (Error.captureStackTrace) {

--- a/test.mjs
+++ b/test.mjs
@@ -134,6 +134,7 @@ test('reject unknown method', async (t) => {
 
   try {
     await rpc.request('echo', Buffer.alloc(0))
+    t.fail()
   } catch (e) {
     t.is(e.code, 'UNKNOWN_METHOD')
   }
@@ -150,6 +151,7 @@ test('reject method after unrespond', async (t) => {
 
   try {
     await rpc.request('echo', Buffer.alloc(0))
+    t.fail()
   } catch (e) {
     t.is(e.code, 'UNKNOWN_METHOD')
   }
@@ -188,6 +190,7 @@ test('rejected request uses custom error code if specified', async (t) => {
 
   try {
     await rpc.request('throw', Buffer.alloc(0))
+    t.fail()
   } catch (e) {
     t.is(e.code, 'REQUEST_ERROR')
     t.is(e.cause.code, 'CUSTOM_ERROR_CODE')

--- a/test.mjs
+++ b/test.mjs
@@ -123,17 +123,10 @@ test('void method', async (t) => {
   )
 })
 
-test.solo('reject unknown method', async (t) => {
-  t.plan(3)
+test('reject unknown method', async (t) => {
   const rpc = new RPC(new PassThrough())
-
-  try {
-    await rpc.request('echo', Buffer.alloc(0))
-  } catch (e) {
-    t.is(e.code, 'REQUEST_ERROR')
-    t.is(e.message, 'REQUEST_ERROR: Request error')
-    t.is(e.cause.message, "unknown method 'echo'")
-  }
+  // await rpc.request('echo', Buffer.alloc(0))
+  await t.exception(rpc.request('echo', Buffer.alloc(0)), /UNKNOWN_METHOD: Unknown method 'echo'/)
 })
 
 test('reject method after unrespond', async (t) => {
@@ -145,7 +138,7 @@ test('reject method after unrespond', async (t) => {
 
   rpc.unrespond('echo')
 
-  await t.exception(rpc.request('echo', Buffer.alloc(0)), /unknown method 'echo'/)
+  await t.exception(rpc.request('echo', Buffer.alloc(0)), /Unknown method 'echo'/)
 })
 
 test('reject request that throws', async (t) => {

--- a/test.mjs
+++ b/test.mjs
@@ -123,10 +123,17 @@ test('void method', async (t) => {
   )
 })
 
-test('reject unknown method', async (t) => {
+test.solo('reject unknown method', async (t) => {
+  t.plan(3)
   const rpc = new RPC(new PassThrough())
 
-  await t.exception(rpc.request('echo', Buffer.alloc(0)), /unknown method 'echo'/)
+  try {
+    await rpc.request('echo', Buffer.alloc(0))
+  } catch (e) {
+    t.is(e.code, 'REQUEST_ERROR')
+    t.is(e.message, 'REQUEST_ERROR: Request error')
+    t.is(e.cause.message, "unknown method 'echo'")
+  }
 })
 
 test('reject method after unrespond', async (t) => {


### PR DESCRIPTION
Edit: the PR changed from the initial, and is now a more generic PR adding clean error messages.

Old PR description below:


This allows the server to pass custom REQUEST_ERROR codes over the RPC, so the client has a clean contract for handling them.

Note: this is currently a breaking change at encoding level (which is why it's a draft PR). It can be made none-breaking by setting a new flag, and parsing messages in the old way if that flag is set. We could also take the opportunity to explicitly version the response encoding.

Note: we could take the opportunity to also expose an `errno` field, as in https://github.com/holepunchto/bare-rpc/blob/7cf145961adfb235e761236bece61aa91ba3f3f7/lib/messages.js#L25-L42 .I think it makes sense, but kept the PR minimal for now

Note: we could also add different error codes for error variants already baked into the code, like 'unknown method' (which currently shows as a REQUEST_ERROR)
