### PR TITLE
Bugfix: cleanup pending timeouts when closing the rpc

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ module.exports = class ProtomuxRPC extends EventEmitter {
 
     for (const request of this._requests.values()) {
       request.reject(err)
+      if (request.timeout) clearTimeout(request.timeout)
     }
 
     this._requests.clear()

--- a/test.mjs
+++ b/test.mjs
@@ -357,19 +357,14 @@ test('timeout', async (t) => {
 })
 
 test('pending timeouts get cleaned up on close', async (t) => {
-  t.plan(2)
+  // This test asserts nothing, but hangs for a day during teardown for its failure case
   const rpc = new RPC(new PassThrough())
 
   rpc.respond('echo', () => {
-    return new Promise((resolve) => {
-      const timeout = [...rpc._requests.values()][0].timeout
-      t.is(timeout._destroyed, false, 'sanity check')
-      rpc.destroy() // trigger clean up logic
-      t.is(timeout._destroyed, true, 'timeout got cleaned up')
-    })
+    rpc.destroy() // trigger clean up logic
   })
 
-  const prom = rpc.request('echo', Buffer.from('hello world'), { timeout: 10_000 })
+  const prom = rpc.request('echo', Buffer.from('hello world'), { timeout: 1000 * 60 * 60 * 24 })
   prom.catch(() => {}) // error expected, since we destroy the rpc
 })
 


### PR DESCRIPTION
Without the fix, the timers stay pending, keeping the node process alive. The test illustrates this, spending 10s in test teardown for the original code.

Note: the test accesses a lot of internals, but I could not find a way to test this with the public API's. I'll remove the test if you prefer; it mostly serves as illustration of the issue.
