### PR TITLE
POC only - error log improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,11 @@ A request ID of `0` indicates an event call and must not be responded to.
 
 #### `response` (`1`)
 
-1.  `bitfield(3)` Flags
+1.  `bitfield(4)` Flags
     1.  `error`
     2.  `code`
     3.  `cause`
+    4.  `context`
 2.  `uint` The ID of the request
 3.  (if `error` is set)
     1.  `string` The error message
@@ -173,7 +174,9 @@ A request ID of `0` indicates an event call and must not be responded to.
 5.  (if `error` and `cause` is set)
     1.  `string` The error cause message
     2.  `string` The error cause code
-6.  (if `error` is not set)
+6.  (if `error` and `context` is set)
+    1.  `string` The error context
+7.  (if `error` is not set)
     1.  `raw` The response value
 
 ## License

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,37 @@
+# Error Handling Architecture
+
+## Context
+
+- All server-side errors are currently logged as `warn`, obscuring severity. We need a standard error taxonomy to map errors to appropriate log levels.
+- Handler throws are wrapped as `REQUEST_ERROR` and serialized to clients, risking exposure of internal details.
+- Because all handler errors are wrapped as `REQUEST_ERROR`, the generic `protomux-rpc-client` lacks actionable signals (e.g., BAD_REQUEST/FORBIDDEN should not be retried).
+- Add a `requestId` to every request/error to enable end-to-end tracing and easier troubleshooting.
+
+## Approach
+
+### Request Tracking
+
+- Server automatically attaches `requestId` to all errors
+- `protomux-rpc` handles encoding/decoding of optional `requestId` values (backward-compatible)
+- Logger add `requestId` in request log
+- Client log/track `requestId` to troubleshoot with server when needed
+
+### Error Standardization
+
+- High-level error categories align with HTTP status code semantics (just some important ones)
+
+### Logging Configuration
+
+- Logger middleware supports configurable mapping from error codes to log levels
+- Sensible defaults provided out-of-the-box following the above error standard
+
+### Client Error Exposure
+
+- Only `RPCError` instances are serialized to clients
+- Unexpected/internal errors are masked as generic `REQUEST_ERROR` responses
+- Full error details are always logged server-side for debugging
+- **Developer responsibility**: Explicitly wrap errors as `RPCError` when client visibility is required
+
+## API sample
+
+See `sample-api.js`

--- a/examples/sample-api.js
+++ b/examples/sample-api.js
@@ -1,0 +1,80 @@
+const errors = require('protomux-rpc/errors')
+const router = new ProtomuxRPCRouter()
+
+// in logger middleware
+logger(console, {
+  // can be overridden by the user, default as below, most of the time you should use default
+  errorLogLevel: {
+    BAD_REQUEST: 'info',
+    FORBIDDEN: 'info',
+    TOO_MANY_REQUESTS: 'warn',
+    CONFLICT: 'info',
+    REQUEST_ERROR: 'error',
+    DECODE_ERROR: 'info',
+    ENCODE_ERROR: 'info',
+    UNKNOWN_METHOD: 'info',
+    DUPLICATE_CHANNEL: 'warn',
+    CHANNEL_CLOSED: 'warn',
+    CHANNEL_DESTROYED: 'warn',
+    default: 'error' // special key for unknown error code
+  }
+})
+
+// in rate limit middleware
+{
+  onrequest: () => {
+    // rate/concurrent limit hits - log as warn
+    throw errors.TOO_MANY_REQUESTS('Rate limit exceeded')
+  }
+}
+
+// in request-id middleware
+
+{
+  onrequest: async (req, next) => {
+    req.requestId = crypto.randomUUID()
+
+    try {
+      return await next()
+    } catch (err) {
+      err.requestId = req.requestId
+
+      throw err
+    }
+  }
+}
+
+// in handler
+router.respond('transfer', async ({ amount, from }, { publicKey }) => {
+  let fromAddress
+  try {
+    fromAddress = parseAddress(from)
+  } catch (err) {
+    // client error - log as info, still has detailed
+    throw errors.BAD_REQUEST('Invalid address', { cause: err })
+  }
+
+  if (from !== publicKey) {
+    // client error - log as info
+    throw errors.FORBIDDEN('Insufficient permissions')
+  }
+
+  if (amount < 0) {
+    // client error - log as info
+    throw errors.BAD_REQUEST('Amount must be positive')
+  }
+
+  const currentBalance = await getBalance(fromAddress)
+  if (currentBalance < amount) {
+    // client error - log as info
+    throw errors.CONFLICT('Insufficient balance')
+  }
+
+  if (shouldShowErrorDetail) {
+    // cause will be serialized to client
+    throw errors.REQUEST_ERROR('Request failed', { cause: new Error('Something went wrong') })
+  } else {
+    // cause will not be serialized to client, client only see REQUEST_ERROR
+    throw new Error('Something went wrong')
+  }
+})

--- a/index.js
+++ b/index.js
@@ -310,9 +310,8 @@ const response = {
       if (m.error.cause) {
         c.string.preencode(state, m.error.cause.message)
         c.string.preencode(state, m.error.cause.code || '')
+        if (m.error.cause.context) c.string.preencode(state, m.error.cause.context)
       }
-
-      if (m.error.context) c.string.preencode(state, m.error.context)
     } else {
       c.raw.preencode(state, m.value)
     }
@@ -324,7 +323,7 @@ const response = {
         !!m.error,
         !!(m.error && m.error.code),
         !!(m.error && m.error.cause),
-        !!(m.error && m.error.context)
+        !!(m.error && m.error.cause && m.error.cause.context)
       )
     )
 
@@ -338,9 +337,8 @@ const response = {
       if (m.error.cause) {
         c.string.encode(state, m.error.cause.message)
         c.string.encode(state, m.error.cause.code || '')
+        if (m.error.cause.context) c.string.encode(state, m.error.cause.context)
       }
-
-      if (m.error.context) c.string.encontext(state, m.error.context)
     } else {
       c.raw.encode(state, m.value)
     }
@@ -364,16 +362,15 @@ const response = {
         cause = new Error(c.string.decode(state))
         const code = c.string.decode(state)
         if (code) cause.code = code
+        if (hasErrorContext) cause.context = c.string.decode(state)
       }
-
-      const context = hasErrorContext ? c.string.decode(state) : null
 
       switch (code) {
         case 'UNKNOWN_METHOD':
           error = errors.UNKNOWN_METHOD(message)
           break
         case 'REQUEST_ERROR':
-          error = errors.REQUEST_ERROR(message, cause, context)
+          error = errors.REQUEST_ERROR(message, cause)
           break
         case 'DECODE_ERROR':
           error = errors.DECODE_ERROR(message, cause)

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,11 +1,11 @@
 module.exports = class RPCError extends Error {
-  constructor(msg, code, fn = RPCError, { cause } = {}) {
+  constructor(msg, code, fn = RPCError, { cause, context } = {}) {
     super(`${code}: ${msg}`, { cause })
     this.code = code
 
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, fn)
-    }
+    if (context) this.context = context
+
+    if (Error.captureStackTrace) Error.captureStackTrace(this, fn)
   }
 
   get name() {
@@ -24,8 +24,8 @@ module.exports = class RPCError extends Error {
     return new RPCError(msg, 'CHANNEL_DESTROYED', RPCError.CHANNEL_DESTROYED)
   }
 
-  static REQUEST_ERROR(msg, cause) {
-    return new RPCError(msg, 'REQUEST_ERROR', RPCError.REQUEST_ERROR, { cause })
+  static REQUEST_ERROR(msg, cause, context) {
+    return new RPCError(msg, 'REQUEST_ERROR', RPCError.REQUEST_ERROR, { cause, context })
   }
 
   static TIMEOUT_EXCEEDED(msg) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -3,8 +3,6 @@ module.exports = class RPCError extends Error {
     super(`${code}: ${msg}`, { cause })
     this.code = code
 
-    if (context) this.context = context
-
     if (Error.captureStackTrace) Error.captureStackTrace(this, fn)
   }
 
@@ -24,8 +22,8 @@ module.exports = class RPCError extends Error {
     return new RPCError(msg, 'CHANNEL_DESTROYED', RPCError.CHANNEL_DESTROYED)
   }
 
-  static REQUEST_ERROR(msg, cause, context) {
-    return new RPCError(msg, 'REQUEST_ERROR', RPCError.REQUEST_ERROR, { cause, context })
+  static REQUEST_ERROR(msg, cause) {
+    return new RPCError(msg, 'REQUEST_ERROR', RPCError.REQUEST_ERROR, { cause })
   }
 
   static TIMEOUT_EXCEEDED(msg) {


### PR DESCRIPTION
# Error Handling Architecture

## Context

- All server-side errors are currently logged as `warn`, obscuring severity. We need a standard error taxonomy to map errors to appropriate log levels.
- Handler throws are wrapped as `REQUEST_ERROR` and serialized to clients, risking exposure of internal details.
- Because all handler errors are wrapped as `REQUEST_ERROR`, the generic `protomux-rpc-client` lacks actionable signals (e.g., BAD_REQUEST/FORBIDDEN should not be retried).
- Add a `requestId` to every request/error to enable end-to-end tracing and easier troubleshooting.

## Approach

### Request Tracking

- Server automatically attaches `requestId` to all errors
- `protomux-rpc` handles encoding/decoding of optional `requestId` values (backward-compatible)
- Logger add `requestId` in request log
- Client log/track `requestId` to troubleshoot with server when needed

### Error Standardization

- High-level error categories align with HTTP status code semantics (just some important ones)

### Logging Configuration

- Logger middleware supports configurable mapping from error codes to log levels
- Sensible defaults provided out-of-the-box following the above error standard

### Client Error Exposure

- Only `RPCError` instances are serialized to clients
- Unexpected/internal errors are masked as generic `REQUEST_ERROR` responses
- Full error details are always logged server-side for debugging
- **Developer responsibility**: Explicitly wrap errors as `RPCError` when client visibility is required

## API sample

See `sample-api.js`
