### PR TITLE
Bump `compact-encoding` to `3.0.0`

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = class ProtomuxRPC extends EventEmitter {
     const {
       id,
       protocol = 'protomux-rpc',
-      valueEncoding = c.buffer,
+      valueEncoding = c.optionalBuffer,
       handshake = null,
       handshakeEncoding
     } = options

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/holepunchto/protomux-rpc#readme",
   "dependencies": {
     "bits-to-bytes": "^1.0.0",
-    "compact-encoding": "^2.6.1",
+    "compact-encoding": "^3.0.0",
     "compact-encoding-bitfield": "^1.0.0",
     "protomux": "^3.7.0",
     "safety-catch": "^1.0.2"


### PR DESCRIPTION
Adjusted the `valueEncoding` for `null` support.

Test `request encode error` threw before changing to `optionalBuffer`
because the `requestEncoding` & `responseEncoding` inheritted from
`valueEncoding`.